### PR TITLE
PIPE-7003 - Use files instead of variables to establish affinityGroup order.

### DIFF
--- a/tests/yaml/S_WF_019.yml
+++ b/tests/yaml/S_WF_019.yml
@@ -20,9 +20,8 @@ pipelines:
           priority: 4
         execution:
           onStart:
-            - echo "step_4_var - ${step_4_var}"
-            - if [ "$step_4_var" != "step_4" ]; then exit 1; fi
-            - add_run_variables step_2_var="step_2"
+            - if [ ! -f $shared_workspace/step_4 ]; then echo "Missing file from step_4"; return 1; fi
+            - echo step_2 > ${shared_workspace}/step_2
           onExecute:
             - echo "step 2 is running"
 
@@ -35,9 +34,13 @@ pipelines:
           priority: 1
         execution:
           onStart:
-            - echo "step_1_var - ${step_1_var}"
             - if [ "$step_1_var" != "step_1" ]; then exit 1; fi
-            - add_run_variables step_3_var="step_3"
+            - if [ -f $shared_workspace/step_2 ]; then echo "step_2 ran first"; return 1; fi
+            - if [ -f $shared_workspace/step_3 ]; then echo "step_3 ran first"; return 1; fi
+            - if [ -f $shared_workspace/step_4 ]; then echo "step_4 ran first"; return 1; fi
+            - if [ -f $shared_workspace/step_5 ]; then echo "step_5 ran first"; return 1; fi
+            - if [ -f $shared_workspace/step_6 ]; then echo "step_6 ran first"; return 1; fi
+            - echo step_3 > ${shared_workspace}/step_3
           onExecute:
             - echo "step 3 is running"
 
@@ -50,9 +53,8 @@ pipelines:
           priority: 3
         execution:
           onStart:
-            - echo "step_3_var - ${step_3_var}"
-            - if [ "$step_3_var" != "step_3" ]; then exit 1; fi
-            - add_run_variables step_4_var="step_4"
+            - if [ ! -f $shared_workspace/step_3 ]; then echo "Missing file from step_3"; return 1; fi
+            - echo step_4 > ${shared_workspace}/step_4
           onExecute:
             - echo "step 4 is running"
 
@@ -67,9 +69,8 @@ pipelines:
           priority: 4
         execution:
           onStart:
-            - echo "step_6_var - ${step_6_var}"
-            - if [ "$step_6_var" != "step_6" ]; then exit 1; fi
-            - add_run_variables step_5_var="step_5"
+            - if [ ! -f $shared_workspace/step_6 ]; then echo "Missing file from step_6"; return 1; fi
+            - echo step_5 > ${shared_workspace}/step_5
           onExecute:
             - echo "step 5 is running"
 
@@ -84,13 +85,10 @@ pipelines:
           priority: 2
         execution:
           onStart:
-            - echo "step_2_var - ${step_2_var}"
-            - echo "step_3_var - ${step_3_var}"
-            - echo "step_4_var - ${step_4_var}"
-            - if [ "$step_2_var" != "step_2" ]; then exit 1; fi
-            - if [ "$step_3_var" != "step_3" ]; then exit 1; fi
-            - if [ "$step_4_var" != "step_4" ]; then exit 1; fi
-            - add_run_variables step_6_var="step_6"
+            - if [ ! -f $shared_workspace/step_2 ]; then echo "Missing file from step_2"; return 1; fi
+            - if [ ! -f $shared_workspace/step_3 ]; then echo "Missing file from step_3"; return 1; fi
+            - if [ ! -f $shared_workspace/step_4 ]; then echo "Missing file from step_4"; return 1; fi
+            - echo step_6 > ${shared_workspace}/step_6
           onExecute:
             - echo "step 6 is running"
 
@@ -104,17 +102,11 @@ pipelines:
           priority: 2
         execution:
           onStart:
-            - echo "step_1_var - ${step_1_var}"
-            - echo "step_2_var - ${step_2_var}"
-            - echo "step_3_var - ${step_3_var}"
-            - echo "step_4_var - ${step_4_var}"
-            - echo "step_5_var - ${step_5_var}"
-            - echo "step_6_var - ${step_6_var}"
             - if [ "$step_1_var" != "step_1" ]; then exit 1; fi
-            - if [ "$step_2_var" != "step_2" ]; then exit 1; fi
-            - if [ "$step_3_var" != "step_3" ]; then exit 1; fi
-            - if [ "$step_4_var" != "step_4" ]; then exit 1; fi
-            - if [ "$step_5_var" != "step_5" ]; then exit 1; fi
-            - if [ "$step_6_var" != "step_6" ]; then exit 1; fi
+            - if [ ! -f $shared_workspace/step_2 ]; then echo "Missing file from step_2"; return 1; fi
+            - if [ ! -f $shared_workspace/step_3 ]; then echo "Missing file from step_3"; return 1; fi
+            - if [ ! -f $shared_workspace/step_4 ]; then echo "Missing file from step_4"; return 1; fi
+            - if [ ! -f $shared_workspace/step_5 ]; then echo "Missing file from step_5"; return 1; fi
+            - if [ ! -f $shared_workspace/step_6 ]; then echo "Missing file from step_6"; return 1; fi
           onExecute:
             - echo "step 7 is running"

--- a/tests/yaml/S_WF_028.yml
+++ b/tests/yaml/S_WF_028.yml
@@ -22,9 +22,8 @@ pipelines:
           priority: 4
         execution:
           onStart:
-            - Write-Output "step_4_var - ${step_4_var}"
-            - if ("$step_4_var" -ne "step_4") { throw "variable does not match expected value" }
-            - add_run_variables step_2_var="step_2"
+            - if (-not (Test-Path -Path $shared_workspace/step_4 -PathType Leaf)) { throw "Missing file from step_4" }
+            - Set-Content -Path ${shared_workspace}/step_2 -Value step_2
           onExecute:
             - Write-Output "step 2 is running"
 
@@ -37,9 +36,13 @@ pipelines:
           priority: 1
         execution:
           onStart:
-            - Write-Output "step_1_var - ${step_1_var}"
             - if ("$step_1_var" -ne "step_1") { throw "variable does not match expected value" }
-            - add_run_variables step_3_var="step_3"
+            - if (Test-Path -Path $shared_workspace/step_2 -PathType Leaf) { throw "step_2 ran first" }
+            - if (Test-Path -Path $shared_workspace/step_3 -PathType Leaf) { throw "step_3 ran first" }
+            - if (Test-Path -Path $shared_workspace/step_4 -PathType Leaf) { throw "step_4 ran first" }
+            - if (Test-Path -Path $shared_workspace/step_5 -PathType Leaf) { throw "step_5 ran first" }
+            - if (Test-Path -Path $shared_workspace/step_6 -PathType Leaf) { throw "step_6 ran first" }
+            - Set-Content -Path ${shared_workspace}/step_3 -Value step_3
           onExecute:
             - Write-Output "step 3 is running"
 
@@ -52,9 +55,8 @@ pipelines:
           priority: 3
         execution:
           onStart:
-            - Write-Output "step_3_var - ${step_3_var}"
-            - if ("$step_3_var" -ne "step_3") { throw "variable does not match expected value" }
-            - add_run_variables step_4_var="step_4"
+            - if (-not (Test-Path -Path $shared_workspace/step_3 -PathType Leaf)) { throw "Missing file from step_3" }
+            - Set-Content -Path ${shared_workspace}/step_4 -Value step_4
           onExecute:
             - Write-Output "step 4 is running"
 
@@ -69,9 +71,8 @@ pipelines:
           priority: 4
         execution:
           onStart:
-            - Write-Output "step_6_var - ${step_6_var}"
-            - if ("$step_6_var" -ne "step_6") { throw "variable does not match expected value" }
-            - add_run_variables step_5_var="step_5"
+            - if (-not (Test-Path -Path $shared_workspace/step_6 -PathType Leaf)) { throw "Missing file from step_6" }
+            - Set-Content -Path ${shared_workspace}/step_5 -Value step_5
           onExecute:
             - Write-Output "step 5 is running"
 
@@ -86,13 +87,10 @@ pipelines:
           priority: 2
         execution:
           onStart:
-            - Write-Output "step_2_var - ${step_2_var}"
-            - Write-Output "step_3_var - ${step_3_var}"
-            - Write-Output "step_4_var - ${step_4_var}"
-            - if ("$step_2_var" -ne "step_2") { throw "variable does not match expected value" }
-            - if ("$step_3_var" -ne "step_3") { throw "variable does not match expected value" }
-            - if ("$step_4_var" -ne "step_4") { throw "variable does not match expected value" }
-            - add_run_variables step_6_var="step_6"
+            - if (-not (Test-Path -Path $shared_workspace/step_2 -PathType Leaf)) { throw "Missing file from step_2" }
+            - if (-not (Test-Path -Path $shared_workspace/step_3 -PathType Leaf)) { throw "Missing file from step_3" }
+            - if (-not (Test-Path -Path $shared_workspace/step_4 -PathType Leaf)) { throw "Missing file from step_4" }
+            - Set-Content -Path ${shared_workspace}/step_6 -Value step_6
           onExecute:
             - Write-Output "step 6 is running"
 
@@ -106,17 +104,11 @@ pipelines:
           priority: 2
         execution:
           onStart:
-            - Write-Output "step_1_var - ${step_1_var}"
-            - Write-Output "step_2_var - ${step_2_var}"
-            - Write-Output "step_3_var - ${step_3_var}"
-            - Write-Output "step_4_var - ${step_4_var}"
-            - Write-Output "step_5_var - ${step_5_var}"
-            - Write-Output "step_6_var - ${step_6_var}"
             - if ("$step_1_var" -ne "step_1") { throw "variable does not match expected value" }
-            - if ("$step_2_var" -ne "step_2") { throw "variable does not match expected value" }
-            - if ("$step_3_var" -ne "step_3") { throw "variable does not match expected value" }
-            - if ("$step_4_var" -ne "step_4") { throw "variable does not match expected value" }
-            - if ("$step_5_var" -ne "step_5") { throw "variable does not match expected value" }
-            - if ("$step_6_var" -ne "step_6") { throw "variable does not match expected value" }
+            - if (-not (Test-Path -Path $shared_workspace/step_2 -PathType Leaf)) { throw "Missing file from step_2" }
+            - if (-not (Test-Path -Path $shared_workspace/step_3 -PathType Leaf)) { throw "Missing file from step_3" }
+            - if (-not (Test-Path -Path $shared_workspace/step_4 -PathType Leaf)) { throw "Missing file from step_4" }
+            - if (-not (Test-Path -Path $shared_workspace/step_5 -PathType Leaf)) { throw "Missing file from step_5" }
+            - if (-not (Test-Path -Path $shared_workspace/step_6 -PathType Leaf)) { throw "Missing file from step_6" }
           onExecute:
             - Write-Output "step 7 is running"


### PR DESCRIPTION
Uses files in the shared workspace instead of variables to establish order for steps that are not an input of the other step.