### PR TITLE
PIPE-6106 - Add valid Dockerfile.

### DIFF
--- a/tests/core/dockerbuild/Dockerfile
+++ b/tests/core/dockerbuild/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:latest
+RUN echo "testing"


### PR DESCRIPTION
The existing Dockerfile build fails.  This one can be used in test cases where successful is preferred.